### PR TITLE
fixed weapon switch when primary ammo is depleted

### DIFF
--- a/src/game/client/hl/hl_baseentity.cpp
+++ b/src/game/client/hl/hl_baseentity.cpp
@@ -332,7 +332,6 @@ int CBasePlayerWeapon::AddToPlayer(CBasePlayer *pPlayer) { return FALSE; }
 int CBasePlayerWeapon::UpdateClientData(CBasePlayer *pPlayer) { return 0; }
 BOOL CBasePlayerWeapon::AddPrimaryAmmo(int iCount, char *szName, int iMaxClip, int iMaxCarry) { return TRUE; }
 BOOL CBasePlayerWeapon::AddSecondaryAmmo(int iCount, char *szName, int iMax) { return TRUE; }
-BOOL CBasePlayerWeapon::IsUseable(void) { return TRUE; }
 int CBasePlayerWeapon::PrimaryAmmoIndex(void) { return -1; }
 int CBasePlayerWeapon::SecondaryAmmoIndex(void) { return -1; }
 void CBasePlayerAmmo::Spawn(void) { }

--- a/src/game/client/hl/hl_weapons.cpp
+++ b/src/game/client/hl/hl_weapons.cpp
@@ -173,11 +173,15 @@ CBasePlayerWeapon:: CanDeploy
 */
 BOOL CBasePlayerWeapon::CanDeploy(void)
 {
-	BOOL bHasAmmo = 0;
+	return IsUseable();
+}
+
+BOOL CBasePlayerWeapon::IsUseable(void) {
+	BOOL bHasAmmo = FALSE;
 
 	if (!pszAmmo1())
 	{
-		// this weapon doesn't use ammo, can always deploy.
+		// this weapon doesn't use ammo, can always be used.
 		return TRUE;
 	}
 
@@ -189,16 +193,12 @@ BOOL CBasePlayerWeapon::CanDeploy(void)
 	{
 		bHasAmmo |= (m_pPlayer->m_rgAmmo[m_iSecondaryAmmoType] != 0);
 	}
-	if (m_iClip > 0)
+	if (!bHasAmmo && m_iClip > 0)
 	{
-		bHasAmmo |= 1;
-	}
-	if (!bHasAmmo)
-	{
-		return FALSE;
+		bHasAmmo |= TRUE;
 	}
 
-	return TRUE;
+	return bHasAmmo;
 }
 
 /*

--- a/src/game/server/weapons.cpp
+++ b/src/game/server/weapons.cpp
@@ -914,20 +914,6 @@ BOOL CBasePlayerWeapon ::AddSecondaryAmmo(int iCount, char *szName, int iMax)
 //=========================================================
 BOOL CBasePlayerWeapon ::IsUseable(void)
 {
-	if (m_iClip <= 0)
-	{
-		if (m_pPlayer->m_rgAmmo[PrimaryAmmoIndex()] <= 0 && iMaxAmmo1() != -1)
-		{
-			// clip is empty (or nonexistant) and the player has no more ammo of this type.
-			return FALSE;
-		}
-	}
-
-	return TRUE;
-}
-
-BOOL CBasePlayerWeapon ::CanDeploy(void)
-{
 	BOOL bHasAmmo = 0;
 
 	if (!pszAmmo1())
@@ -944,16 +930,17 @@ BOOL CBasePlayerWeapon ::CanDeploy(void)
 	{
 		bHasAmmo |= (m_pPlayer->m_rgAmmo[m_iSecondaryAmmoType] > 0);
 	}
-	if (m_iClip > 0)
+	if (!bHasAmmo && m_iClip > 0)
 	{
-		bHasAmmo |= 1;
+		bHasAmmo |= TRUE;
 	}
-	if (!bHasAmmo)
-	{
-		return FALSE;
-	}
+	
+	return bHasAmmo;
+}
 
-	return TRUE;
+BOOL CBasePlayerWeapon ::CanDeploy(void)
+{
+	return IsUseable();
 }
 
 BOOL CBasePlayerWeapon ::DefaultDeploy(char *szViewModel, char *szWeaponModel, int iAnim, char *szAnimExt, int skiplocal /* = 0 */, int body)


### PR DESCRIPTION
The behavior of CBasePlayerWeapon::CanDeploy method has been modified to directly depend on IsUseable.
IsUseable now checks if the weapon has secondary ammo left. This allows weapons with secondary ammo (such as mp5) to remain useable if the primary ammo is depleted.

Gameplay changes:
Due to this fix, the player now can use the mp5 grenade launcher without 9mm ammo.
This change also fixes the strange behavior of the lastinv command, which automatically switches back from mp5 when it has only secondary ammo left.