### PR TITLE
weapon ammo add reload

### DIFF
--- a/src/game/server/weapons.cpp
+++ b/src/game/server/weapons.cpp
@@ -864,9 +864,12 @@ BOOL CBasePlayerWeapon ::AddPrimaryAmmo(int iCount, char *szName, int iMaxClip, 
 	}
 	else if (m_iClip == 0)
 	{
-		int i;
-		i = min(m_iClip + iCount, iMaxClip) - m_iClip;
-		m_iClip += i;
+		int i = 0;
+		if (m_pPlayer->HasPlayerItem(this))
+		{
+			i = min(m_iClip + iCount, iMaxClip) - m_iClip;
+			m_iClip += i;
+		}
 		iIdAmmo = m_pPlayer->GiveAmmo(iCount - i, szName, iMaxCarry);
 	}
 	else


### PR DESCRIPTION
Prior to adding this change, when the current weapon's ammo runs out, and the player touches a weapon with the same ammo type, the ammo is added directly to the weapon clip.
Now, the ammo is added to the inventory, forcing the weapon to reload.