### PR TITLE
fixes 2/9

### DIFF
--- a/src/game/server/game.cpp
+++ b/src/game/server/game.cpp
@@ -54,6 +54,7 @@ cvar_t teamlist = { "mp_teamlist", "hgrunt;scientist", FCVAR_SERVER };
 cvar_t teamoverride = { "mp_teamoverride", "1" }; // Could or not a map override team list
 cvar_t defaultteam = { "mp_defaultteam", "0" }; // Players are forced to first team in the team list
 cvar_t allowmonsters = { "mp_allowmonsters", "0", FCVAR_SERVER };
+cvar_t frictiontriggers = { "mp_frictiontriggers", "0", FCVAR_SERVER };
 
 cvar_t mp_chattime = { "mp_chattime", "10", FCVAR_SERVER };
 cvar_t mp_notify_player_status = { "mp_notify_player_status", "7" }; // Notifications about join/leave/spectate
@@ -505,6 +506,7 @@ void GameDLLInit(void)
 	CVAR_REGISTER(&teamoverride);
 	CVAR_REGISTER(&defaultteam);
 	CVAR_REGISTER(&allowmonsters);
+	CVAR_REGISTER(&frictiontriggers);
 
 	CVAR_REGISTER(&mp_chattime);
 	CVAR_REGISTER(&mp_notify_player_status);

--- a/src/game/server/game.h
+++ b/src/game/server/game.h
@@ -42,6 +42,7 @@ extern cvar_t teamlist;
 extern cvar_t teamoverride;
 extern cvar_t defaultteam;
 extern cvar_t allowmonsters;
+extern cvar_t frictiontriggers;
 extern cvar_t mp_notify_player_status;
 extern cvar_t mp_welcomecam;
 extern cvar_t mp_respawn_fix;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -1712,7 +1712,7 @@ void CBasePlayer::Jump()
 
 	SetAnimation(PLAYER_JUMP);
 
-	if (m_fLongJump && (pev->button & IN_DUCK) && (pev->flDuckTime > 0) && pev->velocity.Length() > 50)
+	if (m_fLongJump && (pev->button & IN_DUCK) && pev->velocity.Length() > 50)
 	{
 		SetAnimation(PLAYER_SUPERJUMP);
 	}

--- a/src/game/server/triggers.cpp
+++ b/src/game/server/triggers.cpp
@@ -77,7 +77,7 @@ void CFrictionModifier ::Spawn(void)
 // Sets toucher's friction to m_frictionFraction (1.0 = normal friction)
 void CFrictionModifier ::ChangeFriction(CBaseEntity *pOther)
 {
-	if (pOther->pev->movetype != MOVETYPE_BOUNCEMISSILE && pOther->pev->movetype != MOVETYPE_BOUNCE)
+	if (pOther->pev->movetype != MOVETYPE_BOUNCEMISSILE && pOther->pev->movetype != MOVETYPE_BOUNCE && (!g_pGameRules->IsMultiplayer() || CVAR_GET_FLOAT("mp_frictiontriggers") > 0))
 		pOther->pev->friction = m_frictionFraction;
 }
 

--- a/src/game/server/weapons.cpp
+++ b/src/game/server/weapons.cpp
@@ -865,7 +865,7 @@ BOOL CBasePlayerWeapon ::AddPrimaryAmmo(int iCount, char *szName, int iMaxClip, 
 	else if (m_iClip == 0)
 	{
 		int i = 0;
-		if (m_pPlayer->HasPlayerItem(this))
+		if (!m_pPlayer->HasPlayerItem(this))
 		{
 			i = min(m_iClip + iCount, iMaxClip) - m_iClip;
 			m_iClip += i;

--- a/src/pm_shared/pm_shared.cpp
+++ b/src/pm_shared/pm_shared.cpp
@@ -3472,7 +3472,7 @@ void PM_Move(struct playermove_s *ppmove, int server)
 	}
 
 	// In single player, reset friction after each movement to FrictionModifier Triggers work still.
-	if (!pmove->multiplayer && (pmove->movetype == MOVETYPE_WALK))
+	if (pmove->movetype == MOVETYPE_WALK)
 	{
 		pmove->friction = 1.0f;
 	}


### PR DESCRIPTION
Fixed wrong evaluation in ammo add function, introduced in the previous fix.
Fixed friction triggers in multiplayer.
Added a cvar to enable/disable friction triggers in multiplayer.
Fixed longjump animation not triggering when invoked from fast key press or using the +ljump command.